### PR TITLE
add end_of_stream hint for tcp streams

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,4 +57,8 @@ execute_process(
 	OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+# jenkins being stupid
+SET(CPACK_PACKAGE_NAME libreass-dev)
+SET(BUILD_TAG "${CPACK_PACKAGE_VERSION}")
+
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ ENDIF()
 add_definitions(-Wall)
 #add_definitions(-std=gnu++0x)
 add_definitions(-DBOOST_TEST_DYN_LINK)
-add_definitions(-march=native)
+add_definitions(-march=core2 -mtune=core2)
 
 if(NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb3")

--- a/lib/packet_listener.h
+++ b/lib/packet_listener.h
@@ -56,6 +56,11 @@ public:
 		packet->release(); // done with packet
 	}
 
+	// saw a fin or rst in a tcp stream, called at most once per stream
+	virtual void end_of_stream(tcp_stream_t *stream)
+	{
+	}
+
 	// called with extra information about where the packet is in the
 	// engine. Make sure to also override all other methods in this
 	// class, debug_packet is only called for events not reported by

--- a/lib/tcp_reassembler.h
+++ b/lib/tcp_reassembler.h
@@ -93,6 +93,7 @@ protected: // internal
 	seq_nr_t d_next_seq;
 	seq_nr_t d_smallest_ack; // used to detect packet loss in first packets
 	bool d_have_accepted_end;
+	bool d_have_sent_end;
 
 	enum direction_t { direction_unknown, direction_initiator, direction_responder };
 	direction_t d_direction;


### PR DESCRIPTION
Add support for hinting that a tcp_stream will likely not receive any more data if both halves have seen a fin or reset.

This introduces a new optional callback for the listener called 'end_of_stream'.