### PR TITLE
change in the Declaration of variable i in stream_t::accept_tcp()

### DIFF
--- a/demo/reass_printall.cpp
+++ b/demo/reass_printall.cpp
@@ -36,7 +36,7 @@ struct stream_t
 			// find eol and print
 			while (1)
 			{
-				std::string::size_type i = d_data.find('\n');
+				i = d_data.find('\n');
 				if (i == std::string::npos)
 					break;
 
@@ -53,6 +53,8 @@ struct stream_t
 
 protected:
 	std::string d_prefix, d_data;
+	std::string::size_type i;
+  
 };
 
 class my_packet_listener_t : public packet_listener_t


### PR DESCRIPTION
Hello,

I have done a fix for the declaration of the variable i in stream_t::accept_tcp() in reass/demo/reass_printall.cpp. This gives a compile time error as the declaration is not within the scope. Please review it and let me know. If the fix is good, please give me the write access to merge.

Regards,
Jos Collin